### PR TITLE
Fixed 1 issue of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ ODD_HEX_NUM = 225248913302192562869270621870514764431976732013487544080065300317
 
 
 def test_decimal():
-    assert Decimal(0.8)==Decimal('0.8')
+    assert Decimal(0.8) == Decimal('0.8')
 
 
 class TestBytesToHex:


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.