### PR TITLE
Fixed 5 issues of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/bitsv/network/services.py
+++ b/bitsv/network/services.py
@@ -44,11 +44,11 @@ class BitIndex:
             'Accept': 'application/json'
         }
         r = requests.post('https://api.bitindex.network/api/addrs/utxo', data=json_payload, headers=headers)
-        return [Unspent(amount = currency_to_satoshi(tx['amount'], 'bsv'),
-             script = tx['scriptPubKey'],
-             txid = tx['txid'],
-             txindex = tx['vout'],
-             confirmations = tx['confirmations']) for tx in r.json()]
+        return [Unspent(amount=currency_to_satoshi(tx['amount'], 'bsv'),
+             script=tx['scriptPubKey'],
+             txid=tx['txid'],
+             txindex=tx['vout'],
+             confirmations=tx['confirmations']) for tx in r.json()]
 
     @staticmethod
     def broadcast_rawtx(rawtx):


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.