### PR TITLE
Fixed 2 issues of type: PYTHON_W391 throughout 2 files in repo.

### DIFF
--- a/bitsv/network/transaction.py
+++ b/bitsv/network/transaction.py
@@ -61,4 +61,3 @@ class TxPart:
             return "OP_RETURN data with {:.0f} satoshi burned".format(self.amount)
         else:
             return "{} with {:.0f} satoshi".format(self.address, self.amount)
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,6 +178,3 @@ texinfo_documents = [
      author, 'BitSV', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.