### PR TITLE
Fixed 24 issues of type: PYTHON_F401 throughout 9 files in repo.

### DIFF
--- a/bitsv/__init__.py
+++ b/bitsv/__init__.py
@@ -1,7 +1,2 @@
-from bitsv.format import verify_sig
-from bitsv.network.rates import SUPPORTED_CURRENCIES, set_rate_cache_time
-from bitsv.network.services import set_service_timeout
-from bitsv.wallet import Key, PrivateKey, PrivateKeyTestnet, wif_to_key
-from bitsv.bip32utils import Bip32utils
 
 __version__ = '0.6.0'

--- a/bitsv/bip32utils.py
+++ b/bitsv/bip32utils.py
@@ -1,6 +1,5 @@
 import pycoin
 
-from pycoin import key
 
 # Popular derivation paths
 DERIVATION_PATH_HANDCASH = '0'

--- a/bitsv/crypto.py
+++ b/bitsv/crypto.py
@@ -1,6 +1,5 @@
 from hashlib import new, sha256 as _sha256
 
-from coincurve import PrivateKey as ECPrivateKey, PublicKey as ECPublicKey
 
 
 def sha256(bytestr):

--- a/bitsv/network/__init__.py
+++ b/bitsv/network/__init__.py
@@ -1,6 +1,4 @@
-from .fees import get_fee
 from .rates import (
     currency_to_satoshi, currency_to_satoshi_cached,
     satoshi_to_currency, satoshi_to_currency_cached
 )
-from .services import NetworkAPI

--- a/tests/network/test_rates.py
+++ b/tests/network/test_rates.py
@@ -1,12 +1,9 @@
-from time import sleep, time
 
-import bitsv
 from bitsv.network.rates import (
     RatesAPI, bsv_to_satoshi, currency_to_satoshi, currency_to_satoshi_cached,
     mbsv_to_satoshi, satoshi_to_currency, satoshi_to_currency_cached,
     satoshi_to_satoshi, set_rate_cache_time, ubsv_to_satoshi
 )
-from bitsv.utils import Decimal
 
 
 # FIXME: No API, so taking this out for now.

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,6 +1,4 @@
 import os
-import time
-import logging
 
 import pytest
 


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        