### PR TITLE
Update travis --> python 3.7 (requires xenial dist) and pypy3.5-6.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial  # required for Python >= 3.7
 language: python
 
 matrix:
@@ -6,7 +7,9 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: pypy3
+        - python: 3.7
+          env: TOXENV=py37
+        - python: pypy3.5-6.0
           env: TOXENV=pypy3
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,12 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
 
-    install_requires=['coincurve>=4.3.0', 'requests', 'cashaddress==1.0.4', 'pycoin'],
+    install_requires=['coincurve>=4.3.0', 'requests', 'cashaddress==1.0.4', 'pycoin==0.80'],
     extras_require={
         'cli': ('appdirs', 'click', 'privy', 'tinydb'),
         'cache': ('lmdb', ),

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py35,
     py36,
+    py37,
     pypy3
 
 [testenv]


### PR DESCRIPTION
Needed to change the travis dist to "xenial" in order to upgrade to python 3.7.
This in turn caused issues with pypy not being able to be downloaded... needed to specify pypy3.5-6.0 as per: https://docs.travis-ci.com/user/reference/xenial/#python-support recommendation

pycoin now also pegged to version 0.80 in setup.py (heavily used for bip32 functionality)

All four builds passing now (py35, py36, py37, pypy3)