### PR TITLE
Adds retry support in network.py

### DIFF
--- a/bitsv/network/services/bitindex3.py
+++ b/bitsv/network/services/bitindex3.py
@@ -51,6 +51,7 @@ class BitIndex3:
             data=json.dumps({'addrs': address}),
             headers=self.headers,
         )
+        r.raise_for_status()
         return [Unspent(
             amount=tx['satoshis'],
             confirmations=tx['confirmations'],
@@ -69,6 +70,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/addr/{address}',
             headers=self.headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_transactions(
@@ -102,6 +104,7 @@ class BitIndex3:
             }),
             headers=self.headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def send_transaction(self, raw_transaction):
@@ -115,6 +118,7 @@ class BitIndex3:
             data=json.dumps({'rawtx': raw_transaction}),
             headers=self.headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_transaction(self, transaction_id):
@@ -127,6 +131,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/tx/{transaction_id}',
             headers=self.headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_raw_transaction(self, transaction_id):
@@ -139,6 +144,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/rawtx/{transaction_id}',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_network_status(self, query=None):
@@ -152,6 +158,7 @@ class BitIndex3:
             params={'q': query},
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_block_hash_by_height(self, height):
@@ -164,6 +171,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/block-index/{height}',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_block(self, block_hash):
@@ -176,6 +184,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/block/{block_hash}',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_raw_block(self, block_hash):
@@ -188,6 +197,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/rawblock/{block_hash}',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_next_address(self, xpub, reserve_time=None):
@@ -202,6 +212,7 @@ class BitIndex3:
             params={'reserveTime': reserve_time},
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_xpub_addresses(
@@ -225,12 +236,13 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/xpub/{xpub}/addrs',
             params={
                 'offset': offset,
-                'limit': 1000,
+                'limit': limit,
                 'order': order,
                 'address': address,
             },
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_xpub_status(self, xpub):
@@ -243,6 +255,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/xpub/{xpub}/status',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_xpub_utxos(self, xpub, sort=None):
@@ -257,6 +270,7 @@ class BitIndex3:
             params={'sort': sort},
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_xpub_transactions(self, xpub):
@@ -269,6 +283,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/xpub/{xpub}/txs',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_webhook_config(self):
@@ -279,6 +294,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/webhook/endpoint',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def update_webhook_config(self, url, enabled, secret):
@@ -298,6 +314,7 @@ class BitIndex3:
             }),
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def get_webhook_monitored_addresses(self):
@@ -308,6 +325,7 @@ class BitIndex3:
             f'https://api.bitindex.network/api/v3/{self.network}/webhook/monitored_addrs',
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
     def update_webhook_monitored_addresses(self, address):
@@ -321,6 +339,7 @@ class BitIndex3:
             data=json.dumps({'addr': address}),
             headers=self.authorized_headers,
         )
+        r.raise_for_status()
         return r.json()
 
 

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -1,8 +1,7 @@
-from datetime import time
-
 from functools import wraps
 
 import requests
+import time
 import collections
 from .bitindex3 import BitIndex3
 

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -9,7 +9,8 @@ from .bitindex3 import BitIndex3
 DEFAULT_TIMEOUT = 30
 BSV_TO_SAT_MULTIPLIER = 100000000
 DEFAULT_RETRY = 3
-IGNORED_ERRORS = (requests.exceptions.ConnectionError,
+IGNORED_ERRORS = (ConnectionError,
+                  requests.exceptions.ConnectionError,
                   requests.exceptions.Timeout,
                   requests.exceptions.ReadTimeout,
                   requests.HTTPError)

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -142,7 +142,7 @@ class NetworkAPI:
         for api_call in self.GET_BALANCE:
             try:
                 return self.retry_wrapper_call(api_call, address)
-            except self.IGNORED_ERRORS:
+            except IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
         raise ConnectionError('All APIs are unreachable.')
@@ -217,7 +217,7 @@ class NetworkAPI:
                 if not success:
                     continue
                 return
-            except self.IGNORED_ERRORS:
+            except IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
         if success is False:

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -1,14 +1,68 @@
+from datetime import time
+
+from functools import wraps
+
 import requests
 import collections
 from .bitindex3 import BitIndex3
 
 DEFAULT_TIMEOUT = 30
 BSV_TO_SAT_MULTIPLIER = 100000000
+DEFAULT_RETRY = 3
+IGNORED_ERRORS = (requests.exceptions.ConnectionError,
+                  requests.exceptions.Timeout,
+                  requests.exceptions.ReadTimeout,
+                  requests.HTTPError)
 
 
 def set_service_timeout(seconds):
     global DEFAULT_TIMEOUT
     DEFAULT_TIMEOUT = seconds
+
+
+def set_service_retry(retry):
+    global DEFAULT_RETRY
+    DEFAULT_RETRY = retry
+
+
+def retry(exception_to_check, tries=3, delay=1, backoff=2, logger=None):
+    """Retry calling the decorated function using an exponential backoff,
+    the default dealy sequence is 1s, 2s, 4s, 8s...
+    http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
+    original from: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
+    :param exception_to_check: the exception object to check. may be a tuple of exceptions to check
+    :type exception_to_check: Exception or tuple
+    :param tries: number of times to try (not retry) before giving up
+    :type tries: int
+    :param delay: initial delay between retries in seconds
+    :type delay: int
+    :param backoff: backoff multiplier e.g. value of 2 will double the delay each retry
+    :type backoff: int
+    :param logger: logger to use. If None, print
+    :type logger: logging.Logger instance
+    """
+    def deco_retry(f):
+
+        @wraps(f)
+        def f_retry(*args, **kwargs):
+            mtries, mdelay = tries, delay
+            while mtries > 1:
+                try:
+                    return f(*args, **kwargs)
+                except exception_to_check as e:
+                    msg = "{}, Retrying in {} seconds...".format(str(e), mdelay)
+                    if logger:
+                        logger.warning(msg)
+                    else:
+                        print(msg)
+                    time.sleep(mdelay)
+                    mtries -= 1
+                    mdelay *= backoff
+            return f(*args, **kwargs)
+
+        return f_retry  # true decorator
+
+    return deco_retry
 
 
 class BitIndex3Normalized(BitIndex3):
@@ -72,10 +126,9 @@ class NetworkAPI:
         self.GET_UNSPENTS = [api.get_unspents for api in self.list_of_apis]
         self.BROADCAST_TX = [api.send_transaction for api in self.list_of_apis]
 
-        self.IGNORED_ERRORS = (ConnectionError,
-                               requests.exceptions.ConnectionError,
-                               requests.exceptions.Timeout,
-                               requests.exceptions.ReadTimeout)
+    @retry(IGNORED_ERRORS, tries=DEFAULT_RETRY)
+    def retry_wrapper_call(self, api_call, param):
+        return api_call(param)
 
     def get_balance(self, address):
         """Gets the balance of an address in satoshis.
@@ -88,7 +141,7 @@ class NetworkAPI:
 
         for api_call in self.GET_BALANCE:
             try:
-                return api_call(address)
+                return self.retry_wrapper_call(api_call, address)
             except self.IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
@@ -107,8 +160,8 @@ class NetworkAPI:
 
         for api_call in self.GET_TRANSACTIONS:
             try:
-                return api_call(address)
-            except self.IGNORED_ERRORS:
+                return self.retry_wrapper_call(api_call, address)
+            except IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
         raise ConnectionError('All APIs are unreachable.')
@@ -124,8 +177,8 @@ class NetworkAPI:
 
         for api_call in self.GET_TRANSACTION:
             try:
-                return api_call(txid)
-            except self.IGNORED_ERRORS:
+                return self.retry_wrapper_call(api_call, txid)
+            except IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
         raise ConnectionError('All APIs are unreachable.')
@@ -143,8 +196,8 @@ class NetworkAPI:
 
         for api_call in self.GET_UNSPENTS:
             try:
-                return api_call(address)
-            except self.IGNORED_ERRORS:
+                return self.retry_wrapper_call(api_call, address)
+            except IGNORED_ERRORS:
                 self.list_of_apis.rotate(-1)  # failed api --> back of the que for next time (across all api calls)
 
         raise ConnectionError('All APIs are unreachable.')
@@ -160,7 +213,7 @@ class NetworkAPI:
 
         for api_call in self.BROADCAST_TX:
             try:
-                success = api_call(tx_hex)
+                success = self.retry_wrapper_call(api_call, tx_hex)
                 if not success:
                     continue
                 return

--- a/bitsv/transaction.py
+++ b/bitsv/transaction.py
@@ -167,7 +167,6 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
             messages.append((message, 0))
             total_op_return_size += get_op_return_size(message, custom_pushdata=True)
 
-
     # Include return address in fee estimate.
     total_in = 0
     num_outputs = len(outputs) + 1
@@ -197,7 +196,7 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
 
     remaining = total_in - total_out
 
-    # If the uxto less than dust (546) the miner will not relay that tx.
+    # If the uxto less than dust (546) the miner will not relay that tx, even the service can successful return.
     # Here we put all the remnant (<546) to the miner in this case.
     # We could adjust here when new dust agreement reached in future.
     if remaining > 546:

--- a/bitsv/transaction.py
+++ b/bitsv/transaction.py
@@ -197,7 +197,10 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
 
     remaining = total_in - total_out
 
-    if remaining > 0:
+    # If the uxto less than dust (546) the miner will not relay that tx.
+    # Here we put all the remnant (<546) to the miner in this case.
+    # We could adjust here when new dust agreement reached in future.
+    if remaining > 546:
         outputs.append((leftover, remaining))
     elif remaining < 0:
         raise InsufficientFunds('Balance {} is less than {} (including '

--- a/bitsv/transaction.py
+++ b/bitsv/transaction.py
@@ -13,6 +13,9 @@ VERSION_1 = 0x01.to_bytes(4, byteorder='little')
 SEQUENCE = 0xffffffff.to_bytes(4, byteorder='little')
 LOCK_TIME = 0x00.to_bytes(4, byteorder='little')
 
+# The dust is described in bitcoin-sv/src/primitives/transaction.h
+DUST = 546
+
 ##
 # Python 3 doesn't allow bitwise operators on byte objects...
 HASH_TYPE = 0x01.to_bytes(4, byteorder='little')
@@ -199,7 +202,7 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
     # If the uxto less than dust (546) the miner will not relay that tx, even the service can successful return.
     # Here we put all the remnant (<546) to the miner in this case.
     # We could adjust here when new dust agreement reached in future.
-    if remaining > 546:
+    if remaining > DUST:
         outputs.append((leftover, remaining))
     elif remaining < 0:
         raise InsufficientFunds('Balance {} is less than {} (including '

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import requests
 
 
 def raise_connection_error(*args, **kwargs):
-    requests.get('https://jibber.ish', timeout=0.01, *args, **kwargs)
+    raise requests.ConnectionError
 
 
 def decorate_methods(decorator, *args, **kwargs):


### PR DESCRIPTION
This push tries to keep the original code as much as possible. 

Suppose the handle list is [ServiceA, ServiceB], and service A has some problem who returns 4XX or 5XX. 
Now the retry mechanism is:
1. call Service A, sleep 1s
2. call Service A, sleep 2s
3. call Service A
4. call Service B

@AustEcon @teran-mckinney please help to take a look.
Now I only update the bitindex3.py, will align all other implementations other than bitindex3 to call raise_for_status() in the future push. 
