### PR TITLE
Add bchsvexplorer api for mainnet redundancy only

### DIFF
--- a/bitsv/network/services/__init__.py
+++ b/bitsv/network/services/__init__.py
@@ -4,3 +4,4 @@ from .bitindex3 import (
 from .insight import InsightAPI
 from .network import NetworkAPI, set_service_timeout, DEFAULT_TIMEOUT
 from .whatsonchain import WhatsonchainAPI
+from .bchsvexplorer import BchSVExplorerDotComAPI

--- a/bitsv/network/services/bchsvexplorer.py
+++ b/bitsv/network/services/bchsvexplorer.py
@@ -1,0 +1,83 @@
+import requests
+import json
+from decimal import Decimal
+
+from bitsv.network import currency_to_satoshi
+from bitsv.network.meta import Unspent
+from bitsv.network.transaction import Transaction, TxPart
+
+DEFAULT_TIMEOUT = 30
+BSV_TO_SAT_MULTIPLIER = 100000000
+
+
+class BchSVExplorerDotComAPI:
+    """
+    Simple bitcoin SV REST API --> uses Legacy address format
+    - get_address_info
+    - get_balance
+    - get_transactions
+    - get_transaction
+    - get_unspent
+    - broadcast_tx
+    """
+    MAIN_ENDPOINT = 'https://bchsvexplorer.com/'
+    MAIN_ADDRESS_API = MAIN_ENDPOINT + 'api/addr/{}'
+    MAIN_BALANCE_API = MAIN_ADDRESS_API + '/balance'
+    MAIN_UNSPENT_API = MAIN_ADDRESS_API + '/utxo'
+    MAIN_TX_PUSH_API = MAIN_ENDPOINT + 'api/tx/send/'
+    MAIN_TX_API = MAIN_ENDPOINT + 'api/tx/{}'
+    MAIN_TX_AMOUNT_API = MAIN_TX_API
+    TX_PUSH_PARAM = 'create_rawtx'
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    @classmethod
+    def get_address_info(cls, address):
+        r = requests.get(cls.MAIN_ADDRESS_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        return r.json()
+
+    @classmethod
+    def get_balance(cls, address):
+        r = requests.get(cls.MAIN_BALANCE_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        return r.json()
+
+    @classmethod
+    def get_transactions(cls, address):
+        r = requests.get(cls.MAIN_ADDRESS_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        return r.json()['transactions']
+
+    @classmethod
+    def get_transaction(cls, txid):
+        # FIXME - response not normalized to match other APIs
+        r = requests.get(cls.MAIN_TX_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        return r.json()
+
+    @classmethod
+    def get_unspent(cls, address):
+        r = requests.get(cls.MAIN_UNSPENT_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        return [
+            Unspent(currency_to_satoshi(tx['amount'], 'bsv'),
+                    tx['confirmations'],
+                    tx['scriptPubKey'],
+                    tx['txid'],
+                    tx['vout'])
+            for tx in r.json()
+        ]
+
+    @classmethod
+    def broadcast_tx(cls, rawtx):  # pragma: no cover
+        r = requests.post(
+            'https://bchsvexplorer.com/api/tx/send',
+            data=json.dumps({'rawtx': rawtx}),
+            headers=cls.headers,
+        )
+        r.raise_for_status()
+        return r.json()

--- a/bitsv/network/services/bchsvexplorer.py
+++ b/bitsv/network/services/bchsvexplorer.py
@@ -1,13 +1,13 @@
 import requests
 import json
-from decimal import Decimal
 
 from bitsv.network import currency_to_satoshi
 from bitsv.network.meta import Unspent
+
+# left here as a reminder to normalize get_transaction()
 from bitsv.network.transaction import Transaction, TxPart
 
 DEFAULT_TIMEOUT = 30
-BSV_TO_SAT_MULTIPLIER = 100000000
 
 
 class BchSVExplorerDotComAPI:
@@ -60,7 +60,7 @@ class BchSVExplorerDotComAPI:
         return r.json()
 
     @classmethod
-    def get_unspent(cls, address):
+    def get_unspents(cls, address):
         r = requests.get(cls.MAIN_UNSPENT_API.format(address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [
@@ -73,11 +73,11 @@ class BchSVExplorerDotComAPI:
         ]
 
     @classmethod
-    def broadcast_tx(cls, rawtx):  # pragma: no cover
+    def send_transaction(cls, rawtx):  # pragma: no cover
         r = requests.post(
             'https://bchsvexplorer.com/api/tx/send',
             data=json.dumps({'rawtx': rawtx}),
             headers=cls.headers,
         )
         r.raise_for_status()
-        return r.json()
+        return r.json()['txid']

--- a/bitsv/network/services/bitindex3.py
+++ b/bitsv/network/services/bitindex3.py
@@ -29,7 +29,7 @@ class BitIndex3:
         headers['api_key'] = self.api_key
         return headers
 
-    def get_utxos(self, address, sort=False, sort_direction='asc'):
+    def get_unspents(self, address, sort=False, sort_direction='asc'):
         """Gets all unspent transaction outputs belonging to an address.
 
         :param address: Address to get utxos for
@@ -71,9 +71,22 @@ class BitIndex3:
             headers=self.headers,
         )
         r.raise_for_status()
-        return r.json()
+        return r.json()['balanceSat']
 
-    def get_transactions(
+    def get_transactions(self, address):
+        """
+        Get a list of txids for a given address
+
+        :param address: Address to get balances for
+        """
+        r = requests.get(
+            'https://api.bitindex.network/api/v3/{}/addr/{}'.format(self.network, address),
+            headers=self.headers,
+        )
+        r.raise_for_status()
+        return r.json()['transactions']
+
+    def get_transactions_detailed(
         self,
         address,
         from_index=0,
@@ -83,7 +96,7 @@ class BitIndex3:
         no_spent=True,
     ):
         """
-        Retrieve transactions for an address
+        Retrieve detailed information about transaction history for an address
 
         :param address: Address to get transactions for
         :param from_index:

--- a/bitsv/network/services/insight.py
+++ b/bitsv/network/services/insight.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from bitsv.network import currency_to_satoshi
 from bitsv.network.meta import Unspent
-from bitsv.network.transaction import Transaction, TxPart
+from bitsv.network.transaction import Transaction, TxInput, TxOutput
 
 DEFAULT_TIMEOUT = 30
 BSV_TO_SAT_MULTIPLIER = 100000000
@@ -52,7 +52,7 @@ class InsightAPI:
                          (Decimal(response['fees']) * BSV_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'], txin['scriptSig']['asm'])
+            part = TxInput(txin['addr'], txin['valueSat'], txin['scriptSig']['asm'])
             tx.add_input(part)
 
         for txout in response['vout']:
@@ -60,9 +60,9 @@ class InsightAPI:
             if 'addresses' in txout['scriptPubKey'] and txout['scriptPubKey']['addresses'] is not None:
                 addr = txout['scriptPubKey']['addresses'][0]
 
-            part = TxPart(addr,
-                          (Decimal(txout['value']) * BSV_TO_SAT_MULTIPLIER).normalize(),
-                          txout['scriptPubKey']['asm'])
+            part = TxOutput(addr,
+                            (Decimal(txout['value']) * BSV_TO_SAT_MULTIPLIER).normalize(),
+                            txout['scriptPubKey']['asm'])
             tx.add_output(part)
 
         return tx

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -4,6 +4,7 @@ import requests
 import time
 import collections
 from .bitindex3 import BitIndex3
+from .bchsvexplorer import BchSVExplorerDotComAPI
 
 DEFAULT_TIMEOUT = 30
 BSV_TO_SAT_MULTIPLIER = 100000000
@@ -53,8 +54,6 @@ def retry_annotation(exception_to_check, tries=3, delay=1, backoff=2, logger=Non
                     msg = "{}, Retrying in {} seconds...".format(str(e), mdelay)
                     if logger:
                         logger.warning(msg)
-                    else:
-                        print(msg)
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff
@@ -107,12 +106,13 @@ class NetworkAPI:
 
         # Instantiate Normalized apis
         self.bitindex3 = BitIndex3Normalized(api_key=None, network=self.network)
+        self.bchsvexplorer = BchSVExplorerDotComAPI  # classmethods, mainnet only
         #Example: self.whatsonchain = WhatsonchainNormalized(network=self.network) - https://developers.whatsonchain.com/
         #Example: self.blockchair = BlockchairNormalized(network=network) - https://github.com/Blockchair/Blockchair.Support
 
         # Allows extra apis for 'main' that may not support testnet (e.g. blockchair)
         if network == 'main':
-            self.list_of_apis = collections.deque([self.bitindex3])
+            self.list_of_apis = collections.deque([self.bitindex3, self.bchsvexplorer])
         elif network == 'test':
             self.list_of_apis = collections.deque([self.bitindex3])
         elif network == 'stn':

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -64,34 +64,6 @@ def retry_annotation(exception_to_check, tries=3, delay=1, backoff=2, logger=Non
     return deco_retry
 
 
-class BitIndex3Normalized(BitIndex3):
-
-    def __init__(self, api_key=None, network="main"):
-        self.api_key = api_key
-        self.network = network
-        self.headers = self._get_headers()
-        self.authorized_headers = self._get_authorized_headers()
-
-    def _get_headers(self):
-        return {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-        }
-
-    def _get_authorized_headers(self):
-        headers = self._get_headers()
-        headers['api_key'] = self.api_key
-        return headers
-
-    def get_transactions(self, address):
-        # override "get_transactions" namespace to return a list of txids only to keep all apis the same
-        return self.get_balance(address)['transactions']
-
-    def get_unspents(self, address, sort=None):
-        # rename to "get_unspents" to keep all apis the same name
-        return self.get_utxos(address, sort=sort)
-
-
 class NetworkAPI:
     """
     A Class for handling network API redundancy.
@@ -105,7 +77,7 @@ class NetworkAPI:
         self.network = network
 
         # Instantiate Normalized apis
-        self.bitindex3 = BitIndex3Normalized(api_key=None, network=self.network)
+        self.bitindex3 = BitIndex3(api_key=None, network=self.network)
         self.bchsvexplorer = BchSVExplorerDotComAPI  # classmethods, mainnet only
         #Example: self.whatsonchain = WhatsonchainNormalized(network=self.network) - https://developers.whatsonchain.com/
         #Example: self.blockchair = BlockchairNormalized(network=network) - https://github.com/Blockchair/Blockchair.Support

--- a/bitsv/network/transaction.py
+++ b/bitsv/network/transaction.py
@@ -1,20 +1,19 @@
 
 
 class Transaction:
-    """
-    Representation of a transaction returned from the network.
-    """
+    """Represents a transaction returned from the network."""
 
-    def __init__(self, txid, block, amount_in, amount_out, amount_fee):
+    __slots__ = ('txid', 'amount_in', 'amount_out', 'fee', 'inputs', 'outputs')
+
+    def __init__(self, txid, amount_in, amount_out):
         self.txid = txid
-        self.block = block
+        self.fee = amount_in - amount_out
 
-        if amount_in != amount_out + amount_fee:
-            raise ArithmeticError("the amounts just don't add up!")
+        if amount_in != amount_out + self.fee:
+            raise ArithmeticError("amount in is not equal to amount out + fee.")
 
         self.amount_in = amount_in
         self.amount_out = amount_out
-        self.amount_fee = amount_fee
 
         self.inputs = []
         self.outputs = []
@@ -26,13 +25,31 @@ class Transaction:
         self.outputs.append(part)
 
     def __repr__(self):
-        return "{} in block {} for {:.0f} satoshi ({:.0f} sent + {:.0f} fee) with {} input{} and {} output{}".format(
-                self.txid, self.block, self.amount_in, self.amount_out, self.amount_fee,
-                len(self.inputs), '' if len(self.inputs) == 1 else 's',
-                len(self.outputs), '' if len(self.outputs) == 1 else 's')
+        return 'Transaction(txid={}, amount_in={}, amount_out={}, ' \
+               'fee={}, inputs={}, outputs={})'.format(
+                repr(self.txid),
+                repr(self.amount_in),
+                repr(self.amount_out),
+                repr(self.fee),
+                len(self.inputs),
+                len(self.outputs)
+        )
 
 
-class TxPart:
+class TxInput:
+    """
+    Representation of a single input or output.
+    """
+
+    def __init__(self, address, amount):
+        self.address = address
+        self.amount = amount
+
+    def __repr__(self):
+        return "Input(address={}, amount={:.0f})".format(self.address, self.amount)
+
+
+class TxOutput:
     """
     Representation of a single input or output.
     """
@@ -58,7 +75,6 @@ class TxPart:
 
     def __repr__(self):
         if self.address is None and self.op_return is not None:
-            return "OP_RETURN data with {:.0f} satoshi burned".format(self.amount)
+            return "Output(OP_RETURN={}, amount_burned={})".format(self.message(), self.amount)
         else:
-            return "{} with {:.0f} satoshi".format(self.address, self.amount)
-
+            return "Output(address={}, amount={:.0f})".format(self.address, self.amount)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Here is a possibility to beef up the redundancy **only on mainnet**.

Please note: The get_transaction() is **not normalized** to be the same as what BitIndex3 returns... which probably needs fixing before wiring up to NetworkAPI in case people rely on parsing the json object that is returned...

I did this in a hurry on 4hrs sleep. It's unfinished - but maybe we can use this? (just submit more commits to this branch if you want to)

Needs:
- Normalization and adding to the mainnet list in NetworkAPI.
- Removal of print and remove logging parameter in the retry wrapper - allow upstream logging to handle it