### PR TITLE
make 'prepare_transaction' a @classmethod as it should not require a …

### DIFF
--- a/bitsv/wallet.py
+++ b/bitsv/wallet.py
@@ -493,12 +493,15 @@ class PrivateKey(BaseKey):
 
         return calc_txid(tx_hex)
 
-    def prepare_transaction(self, address, outputs, compressed=True, fee=None, leftover=None,
-                            combine=True, message=None, unspents=None, custom_pushdata=False):  # pragma: no cover
+    @classmethod
+    def prepare_transaction(cls, sender_address, outputs, network, compressed=True, fee=None,
+            leftover=None, combine=True, message=None, unspents=None,
+            custom_pushdata=False):  # pragma: no cover
         """Prepares a P2PKH transaction for offline signing.
 
-        :param address: The address the funds will be sent from.
-        :type address: ``str``
+        :param network: The network ('main', 'test', 'stn')
+        :param sender_address: The address the funds will be sent from.
+        :type sender_address: ``str``
         :param outputs: A sequence of outputs you wish to send in the form
                         ``(destination, amount, currency)``. The amount can
                         be either an int, float, or string as long as it is
@@ -522,23 +525,24 @@ class PrivateKey(BaseKey):
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
                         each message will be stored in chunks of 100kb bytes.
-        :type message: ``str`` if custom_pushdata = False; ``list`` of ``tuple`` if custom_pushdata = True
+        :type message: ``str`` if custom_pushdata = False; ``list`` of ``tuple`` if custom_pushdata
+                        = True
         :param unspents: The UTXOs to use as the inputs. By default BitSV will
                          communicate with the blockchain itself.
         :type unspents: ``list`` of :class:`~bitsv.network.meta.Unspent`
-        :param custom_pushdata: Adds control over push_data elements inside of the op_return by adding the
-                                "custom_pushdata" = True / False parameter as a "switch" to the
-                                :func:`~bitsv.PrivateKey.send` function and the
+        :param custom_pushdata: Adds control over push_data elements inside of the op_return by
+                                adding the "custom_pushdata" = True / False parameter as a
+                                "switch" to the :func:`~bitsv.PrivateKey.send` function and the
                                 :func:`~bitsv.PrivateKey.create_transaction` functions.
         :type custom_pushdata: ``bool``
         :returns: JSON storing data required to create an offline transaction.
         :rtype: ``str``
         """
         unspents, outputs = sanitize_tx_data(
-            unspents or self.network_api.get_unspents(address),
+            unspents or NetworkAPI(network=network).get_unspents(sender_address),
             outputs,
             fee or get_fee(),
-            leftover or address,
+            leftover or sender_address,
             combine=combine,
             message=message,
             compressed=compressed,
@@ -550,7 +554,7 @@ class PrivateKey(BaseKey):
             'outputs': outputs
         }
 
-        return json.dumps(data, separators=(',', ':'))
+        return json.dumps(data)
 
     def sign_transaction(self, tx_data):  # pragma: no cover
         """Creates a signed P2PKH transaction using previously prepared


### PR DESCRIPTION
…private key for offline partial tx preparation

Note: the function signature has now changed from required positional args: (address, outputs) to now (sender_address, outputs, network).

Addresses: https://github.com/AustEcon/bitsv/issues/73