### PR TITLE
Migrated bchsvexplorer to bsvbookguarda, which replaces it.

### DIFF
--- a/bitsv/network/services/__init__.py
+++ b/bitsv/network/services/__init__.py
@@ -2,5 +2,5 @@ from .mattercloud import (
     MatterCloud, MatterCloudMainNet, MatterCloudTestNet, MatterCloudSTN)
 from .network import NetworkAPI, set_service_timeout, DEFAULT_TIMEOUT
 from .whatsonchain import WhatsonchainNormalised
-from .bchsvexplorer import BCHSVExplorerAPI
+from .bsvbookguarda import BSVBookGuardaAPI
 from .fullnode import FullNode

--- a/bitsv/network/services/network.py
+++ b/bitsv/network/services/network.py
@@ -9,7 +9,7 @@ import logging
 from .whatsonchain import WhatsonchainNormalised
 
 from .mattercloud import MatterCloud, MATTERCLOUD_API_KEY_VARNAME
-from .bchsvexplorer import BCHSVExplorerAPI
+from .bsvbookguarda import BSVBookGuardaAPI
 
 DEFAULT_TIMEOUT = 30
 DEFAULT_RETRY = 3
@@ -78,7 +78,7 @@ class NetworkAPI:
         self.network = network
 
         # Instantiate Normalized apis
-        self.bchsvexplorer = BCHSVExplorerAPI  # classmethods, mainnet only
+        self.bchsvexplorer = BSVBookGuardaAPI  # classmethods, mainnet only
         self.whatsonchain = WhatsonchainNormalised(network=self.network)
 
         # Allows extra apis for 'main' that may not support testnet (e.g. blockchair)

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -105,7 +105,7 @@ class TestNetworkAPI:
             mock_network_api_main.get_balance(MAIN_ADDRESS_USED1)
 
     def test_get_transactions_main_equal(self):
-        results = [api.get_transactions(MAIN_ADDRESS_USED1) for api in network_api_main.list_of_apis]
+        results = [[*api.get_transactions(MAIN_ADDRESS_USED1)] for api in network_api_main.list_of_apis]
         assert all_items_common(results[:100])
 
     def test_get_transactions_main_failure(self):


### PR DESCRIPTION
I was having an issue and emailed bchsvexplorer, and guarda.co's support told me that bchsvexplorer is outdated, and that bsvbook.guarda.co replaces it with a modern api.