### PR TITLE
Change some public attributes to properties to eliminate potential problems

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -139,9 +139,9 @@ class TestPrivateKey:
         private_key = PrivateKey()
 
         assert private_key._address is None
-        assert private_key.balance == 0
-        assert private_key.unspents == []
-        assert private_key.transactions == []
+        assert private_key._balance is None
+        assert private_key._unspents is None
+        assert private_key._transactions is None
 
     def test_address(self):
         private_key = PrivateKey(WALLET_FORMAT_MAIN)


### PR DESCRIPTION
Hello, 
I'm a beginner but I noticed that there might be a small problem in the PrivateKey class: 
In this class, you defined balance, unspents, and transactions as public attributes, but initialized them with zero or vacant list. 
If you instantiate a prv key obj without calling get_balance()/get_unspents()/get_transactions() methods, the result of key.balance, key.unspents, key.transactions are all wrong. 
This may be misleading and may trigger potential bugs if your package is used without attention because the public attributes look like properties. 
A good solution is to make these attributes protected and create their corresponding properties, leaving the interface unchanged while solving the consistency problem, just like the self._address attribute does.